### PR TITLE
[#165346115][#165348446][#165537156] S3 Encryption at rest, IP Whitelisting and public bucket

### DIFF
--- a/jobs/s3-broker/spec
+++ b/jobs/s3-broker/spec
@@ -26,6 +26,8 @@ properties:
   s3-broker.iam_user_path:
     description: "Path for the created IAM users"
     default: "/paas-s3-broker/"
+  s3-broker.iam_ip_restriction_policy_arn:
+    description: "ARN for IP restricion policy"
   s3-broker.deploy_environment:
     description: "Environment this broker is deployed into"
   s3-broker.catalog:

--- a/jobs/s3-broker/templates/config/s3-broker-config.json.erb
+++ b/jobs/s3-broker/templates/config/s3-broker-config.json.erb
@@ -7,5 +7,6 @@
   "catalog": <%= JSON.dump(p('s3-broker.catalog')) %>,
   "resource_prefix": "<%= p('s3-broker.resource_prefix') %>",
   "iam_user_path": "<%= p('s3-broker.iam_user_path') %>",
+  "iam_ip_restriction_policy_arn": "<%= p('s3-broker.iam_ip_restriction_policy_arn') %>",
   "deploy_env": "<%= p('s3-broker.deploy_environment') %>"
 }


### PR DESCRIPTION
What
----

Allow the boshrelease to consume the input of the ARN of an IAM policy for IP restriction, and output this to the config file the S3 broker is configured with

Also, add a WIP commit updating the submodule to the latest WIP code.

The submodule *MUST* be updated to the latest tagged release of paas-s3-broker, after https://github.com/alphagov/paas-s3-broker/pull/10 is merged

How to review
-------------

* Code review
* Ensure the submodule points to the latest tag of `paas-s3-broker`, deploy to a dev environment
* Ensure the boshrelease builds

Who can review
--------------

Not @tnwhitwell or @AP-Hunt 
