### PR TITLE
Bumps verison of paas-s3-broker to target aquire_lock_for_editing_buckets branch

### DIFF
--- a/jobs/s3-broker/spec
+++ b/jobs/s3-broker/spec
@@ -4,6 +4,9 @@ name: s3-broker
 templates:
   bin/s3-broker-ctl.erb: bin/s3-broker-ctl
   config/s3-broker-config.json.erb: config/s3-broker-config.json
+  config/locket.ca_cert.crt.erb: config/locket.ca_cert.crt
+  config/locket.client_cert.crt.erb: config/locket.client_cert.crt
+  config/locket.client_key.key.erb: config/locket.client_key.key
 
 packages:
   - s3-broker
@@ -30,5 +33,14 @@ properties:
     description: "ARN for IP restricion policy"
   s3-broker.deploy_environment:
     description: "Environment this broker is deployed into"
+  s3-broker.locket.api_location:
+    description: "The host and port for the Locket server"
+    example: "127.0.0.1:8891"
+  s3-broker.locket.ca_cert:
+    description: "A PEM formatted certificate of a CA the Locket client will trust"
+  s3-broker.locket.client_cert:
+    description: "A PEM formatted certificate used for client connections to the Locket server"
+  s3-broker.locket.client_key:
+    description: "A PEM formatted key used for client connections to the Locket server"
   s3-broker.catalog:
     description: "Broker catalog (including services and plans)"

--- a/jobs/s3-broker/templates/config/locket.ca_cert.crt.erb
+++ b/jobs/s3-broker/templates/config/locket.ca_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('s3-broker.locket.ca_cert') %>

--- a/jobs/s3-broker/templates/config/locket.client_cert.crt.erb
+++ b/jobs/s3-broker/templates/config/locket.client_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('s3-broker.locket.client_cert') %>

--- a/jobs/s3-broker/templates/config/locket.client_key.key.erb
+++ b/jobs/s3-broker/templates/config/locket.client_key.key.erb
@@ -1,0 +1,1 @@
+<%= p('s3-broker.locket.client_key') %>

--- a/jobs/s3-broker/templates/config/s3-broker-config.json.erb
+++ b/jobs/s3-broker/templates/config/s3-broker-config.json.erb
@@ -8,5 +8,9 @@
   "resource_prefix": "<%= p('s3-broker.resource_prefix') %>",
   "iam_user_path": "<%= p('s3-broker.iam_user_path') %>",
   "iam_ip_restriction_policy_arn": "<%= p('s3-broker.iam_ip_restriction_policy_arn') %>",
-  "deploy_env": "<%= p('s3-broker.deploy_environment') %>"
+  "deploy_env": "<%= p('s3-broker.deploy_environment') %>",
+  "locket_address": "<%= p('s3-broker.locket.api_location') %>",
+  "locket_ca_cert_file": "/var/vcap/jobs/s3-broker/config/locket.ca_cert.crt",
+  "locket_client_cert_file": "/var/vcap/jobs/s3-broker/config/locket.client_cert.crt",
+  "locket_client_key_file": "/var/vcap/jobs/s3-broker/config/locket.client_key.key"
 }


### PR DESCRIPTION
What
--- 
Bumps the version of the S3 broker to a version that supports locking on bucket operations. Also adds configuration options for Locket.

How to review
---
1. Code review
2. See [the S3 broker PR](https://github.com/alphagov/paas-s3-broker/pull/16)

Who can review
---
Anyone